### PR TITLE
add interview logic and part of offer

### DIFF
--- a/src/main/java/com/tnite/jobwinner/controller/InterviewController.java
+++ b/src/main/java/com/tnite/jobwinner/controller/InterviewController.java
@@ -1,0 +1,47 @@
+package com.tnite.jobwinner.controller;
+
+import com.tnite.jobwinner.model.Interview;
+import com.tnite.jobwinner.model.AddInterviewInput;
+import com.tnite.jobwinner.service.InterviewService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.MutationMapping;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
+
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Controller
+public class InterviewController {
+
+	@Autowired
+	private InterviewService interviewService;
+
+	@MutationMapping
+	public Mono<Interview> addInterview(@Argument AddInterviewInput interviewInput) {
+		return interviewService.addInterview(interviewInput);
+	}
+
+	@MutationMapping
+	public Mono<Interview> updateInterview(@Argument Interview interview) {
+		return interviewService.updateInterview(interview);
+	}
+
+	@QueryMapping
+	public Flux<Interview> allInterviewByJobApplicationId(@Argument Integer jobApplicationId) {
+		return interviewService.getInterviewByJobApplicationId(jobApplicationId);
+	}
+
+	@QueryMapping
+	public Flux<Interview> allInterview() {
+		return interviewService.allInterview();
+	}
+
+	@QueryMapping
+	public Mono<Interview> interviewById(@Argument Integer id) {
+		return interviewService.getInterview(id);
+	}
+
+}

--- a/src/main/java/com/tnite/jobwinner/model/AddInterviewInput.java
+++ b/src/main/java/com/tnite/jobwinner/model/AddInterviewInput.java
@@ -1,0 +1,19 @@
+package com.tnite.jobwinner.model;
+
+import java.time.LocalDate;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AddInterviewInput {
+	private Integer jobApplicationId;
+	private LocalDate interviewDate;
+	private String interviewer;
+	private String description;
+	private String status;
+
+}

--- a/src/main/java/com/tnite/jobwinner/model/Interview.java
+++ b/src/main/java/com/tnite/jobwinner/model/Interview.java
@@ -1,0 +1,26 @@
+package com.tnite.jobwinner.model;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "interview")
+public class Interview {
+
+	@Id
+	private Integer id;
+	@Column("job_application_id")
+	private Integer jobApplicationId;
+	@Column("interview_date")
+	private LocalDate interviewDate;
+	private String interviewer;
+	private String description;
+	private String status;
+}

--- a/src/main/java/com/tnite/jobwinner/model/Offer.java
+++ b/src/main/java/com/tnite/jobwinner/model/Offer.java
@@ -1,0 +1,28 @@
+package com.tnite.jobwinner.model;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "offer")
+public class Offer {
+
+	@Id
+	private Integer id;
+	@Column("job_application_id")
+	private Integer jobApplicationId;
+	@Column("offer_date")
+	private LocalDate offerDate;
+	@Column("salary_offered")
+	private String salaryOffered;
+	private String description;
+	private String status;
+
+}

--- a/src/main/java/com/tnite/jobwinner/model/OfferInput.java
+++ b/src/main/java/com/tnite/jobwinner/model/OfferInput.java
@@ -1,0 +1,19 @@
+package com.tnite.jobwinner.model;
+
+import java.time.LocalDate;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class OfferInput {
+	private Integer jobApplicationId;
+	private LocalDate offerDate;
+	private String salaryOffered;
+	private String description;
+	private String status;
+
+}

--- a/src/main/java/com/tnite/jobwinner/repo/InterviewRepository.java
+++ b/src/main/java/com/tnite/jobwinner/repo/InterviewRepository.java
@@ -1,0 +1,9 @@
+package com.tnite.jobwinner.repo;
+
+import com.tnite.jobwinner.model.Interview;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+
+public interface InterviewRepository extends ReactiveCrudRepository<Interview, Integer> {
+	Flux<Interview> findAllByJobApplicationId(Integer jobApplicationId);
+}

--- a/src/main/java/com/tnite/jobwinner/repo/ProfileRepository.java
+++ b/src/main/java/com/tnite/jobwinner/repo/ProfileRepository.java
@@ -1,8 +1,7 @@
 package com.tnite.jobwinner.repo;
 
-import org.springframework.data.repository.reactive.ReactiveCrudRepository;
-
 import com.tnite.jobwinner.model.Profile;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 
 public interface ProfileRepository extends ReactiveCrudRepository<Profile, Integer>{
 

--- a/src/main/java/com/tnite/jobwinner/service/InterviewService.java
+++ b/src/main/java/com/tnite/jobwinner/service/InterviewService.java
@@ -1,0 +1,76 @@
+package com.tnite.jobwinner.service;
+
+import com.tnite.jobwinner.model.Interview;
+import com.tnite.jobwinner.model.AddInterviewInput;
+import com.tnite.jobwinner.repo.InterviewRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+@Slf4j
+public class InterviewService {
+
+	@Autowired
+	private InterviewRepository interviewRepository;
+
+	private Interview mapToInterview(AddInterviewInput interviewInput) {
+		var interview = new Interview();
+		interview.setJobApplicationId(interviewInput.getJobApplicationId());
+		interview.setInterviewDate(interviewInput.getInterviewDate());
+		interview.setInterviewer(interviewInput.getInterviewer());
+		interview.setDescription(interviewInput.getDescription());
+		interview.setStatus(interviewInput.getStatus());
+		return interview;
+	}
+
+	public Mono<Interview> addInterview(AddInterviewInput interviewInput) {
+		Interview interview = mapToInterview(interviewInput);
+		return interviewRepository.save(interview)
+			.doOnSuccess(p -> log.info("Added new interview: {}", p))
+			.doOnError(e -> log.error("Failed to add interview: {}", interviewInput, e));
+	}
+
+	public Mono<Interview> updateInterview(Interview interview) {
+		return interviewRepository.findById(interview.getId())
+			.flatMap(existingInterview -> {
+				updateInterviewDetails(existingInterview, interview);
+				return interviewRepository.save(existingInterview);
+			})
+			.doOnSuccess(p -> log.info("Updated interview: {}", p))
+			.doOnError(e -> log.error("Failed to update interview: {}", interview, e));
+	}
+
+	private void updateInterviewDetails(Interview existingInterview, Interview updatedInterview) {
+		existingInterview.setJobApplicationId(updatedInterview.getJobApplicationId());
+		existingInterview.setInterviewDate(updatedInterview.getInterviewDate());
+		existingInterview.setInterviewer(updatedInterview.getInterviewer());
+		existingInterview.setDescription(updatedInterview.getDescription());
+		existingInterview.setStatus(updatedInterview.getStatus());
+	}
+
+	public Flux<Interview> getInterviewByJobApplicationId(Integer jobApplicationId) {
+		return interviewRepository.findAllByJobApplicationId(jobApplicationId)
+			.doOnComplete(() -> log.info("Retrieved all interviews for job application id {}", jobApplicationId))
+			.doOnError(e -> log.error("Failed to retrieve all interviews for job application id {}", jobApplicationId, e));
+	}
+
+	public Flux<Interview> allInterview() {
+		return interviewRepository.findAll()
+			.doOnComplete(() -> log.info("Retrieved all interviews"))
+			.doOnError(e -> log.error("Failed to retrieve interviews", e));
+	}
+
+	public Mono<Interview> getInterview(Integer id) {
+		return interviewRepository.findById(id)
+			.switchIfEmpty(Mono.defer(() -> {
+				log.warn("Interview with id {} not found", id);
+				return Mono.empty();
+			}))
+			.doOnSuccess(profile -> log.info("Retrieved interview: {}", profile))
+			.doOnError(e -> log.error("Failed to retrieve interview with id {}", id, e));
+	}
+
+}

--- a/src/main/java/com/tnite/jobwinner/service/JobApplicationService.java
+++ b/src/main/java/com/tnite/jobwinner/service/JobApplicationService.java
@@ -76,7 +76,7 @@ public class JobApplicationService {
         if (Objects.isNull(jobApplication)) {
             return Mono.empty();
         }
-        log.info("Deleting job application idd {}", id);
+        log.info("Deleting job application id {}", id);
         return this.jobApplicationRepository.findById(id).switchIfEmpty(Mono.empty()).filter(Objects::nonNull)
                 .flatMap(jobApplicationToBeDeleted -> jobApplicationRepository
                         .delete(jobApplicationToBeDeleted)

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -5,6 +5,10 @@ type Query {
     profileById(id: ID): Profile
     allProfile: [Profile]
     searchJobApplications(searchTerm: String!): [JobApplication]
+    allInterview: [Interview]
+    allInterviewByJobApplicationId(jobApplicationId: Int!): [Interview]
+    interviewById(id: ID): Interview
+    allOfferByApplicationId(jobApplicationId: Int!): [Offer]
 }
 
 type JobApplication {
@@ -32,12 +36,34 @@ type Profile {
     personalWebsite: String
 }
 
+type Offer {
+    id: ID!
+    jobApplicationId: Int!
+    offerDate: String!
+    salaryOffered: String
+    description: String
+    status: String
+}
+
+type Interview {
+    id: ID!
+    jobApplicationId: Int!
+    interviewDate: String!
+    interviewer: String
+    description: String
+    status: String
+}
+
 type Mutation {
     addJobApplication(addJobApplicationInput: AddJobApplicationInput): JobApplication
-    updateJobApplication(jobApplication: UpdateJobApplicationInput): JobApplication  
+    updateJobApplication(jobApplication: UpdateJobApplicationInput): JobApplication
     deleteJobApplication(id: ID): JobApplication
     addProfile(addProfileInput: AddProfileInput): Profile
     updateProfile(profile: UpdateProfileInput): Profile
+    addInterview(interviewInput: AddInterviewInput): Interview
+    updateInterview(id: ID!, interview: UpdateInterviewInput): Interview
+    addOffer(offerInput: AddOfferInput): Offer
+    updateOffer(id: ID!, offer: UpdateOfferInput): Offer
 }
 
 input AddJobApplicationInput {
@@ -86,4 +112,37 @@ input UpdateProfileInput {
     linkedin: String
     github: String
     personalWebsite: String
+}
+
+input AddInterviewInput {
+    jobApplicationId: Int!
+    interviewDate: String!
+    interviewer: String
+    description: String
+    status: String
+}
+
+input UpdateInterviewInput {
+    id: ID!
+    jobApplicationId: Int!
+    interviewDate: String!
+    interviewer: String
+    description: String
+    status: String
+}
+
+input AddOfferInput {
+    jobApplicationId: Int!
+    offerDate: String!
+    salaryOffered: String
+    description: String
+    status: String
+}
+
+input UpdateOfferInput {
+    jobApplicationId: Int!
+    offerDate: String!
+    salaryOffered: String
+    description: String
+    status: String
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -23,5 +23,25 @@ create table if not exists profile(
     personal_website varchar(200)
 );
 
+create table if not exists interview (
+    id serial primary key,
+    job_application_id int not null,
+    interview_date date not null,
+    interviewer varchar(255),
+    description varchar(500),
+    status varchar(20),
+    foreign key (job_application_id) references job_application(id) on delete cascade
+);
+
+create table if not exists offer (
+    id serial primary key,
+    job_application_id int not null,
+    offer_date date not null,
+    salary_offered varchar(255),
+    description varchar(500),
+    status varchar(20),
+    foreign key (job_application_id) references job_application(id) on delete cascade
+);
+
 insert into profile(id)
     values(1);

--- a/src/test/java/com/tnite/jobwinner/controller/InterviewGraphQlTest.java
+++ b/src/test/java/com/tnite/jobwinner/controller/InterviewGraphQlTest.java
@@ -1,0 +1,235 @@
+package com.tnite.jobwinner.controller;
+
+
+import com.tnite.jobwinner.model.Interview;
+import com.tnite.jobwinner.model.JobApplication;
+import com.tnite.jobwinner.repo.InterviewRepository;
+import com.tnite.jobwinner.repo.JobApplicationRepository;
+import com.tnite.jobwinner.repo.ProfileRepository;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.graphql.tester.AutoConfigureGraphQlTester;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.graphql.test.tester.GraphQlTester;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@AutoConfigureGraphQlTester
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@TestPropertySource(properties = {
+	"spring.r2dbc.url=r2dbc:h2:mem:///testdb-${random.uuid}",
+	"spring.r2dbc.generate-unique-name=true",
+})
+@ExtendWith(MockitoExtension.class)
+public class InterviewGraphQlTest {
+
+    @Autowired
+    private GraphQlTester graphQlTester;
+
+    @MockBean
+    InterviewRepository interviewRepository;
+
+    private Interview interview1;
+    private Interview interview2;
+    private Interview interview3;
+    private Interview interview1_updated;
+
+    @BeforeEach
+    void setUp() {
+        interview1 = new Interview(1, 1, LocalDate.of(2024, 9, 2), "John Doe", "Technical interview", "scheduled");
+        interview2 = new Interview(2, 1, LocalDate.now(), "Jane Doe", "HR interview", "closed");
+        interview3 = new Interview(3, 2, LocalDate.now(), "Jane Doe", "HR interview", "scheduled");
+        interview1_updated = new Interview(1, 1, LocalDate.of(2024, 9, 2), "John Doe", "Technical interview", "closed");
+    }
+
+    @Test
+    void testAllInterview() {
+
+        when(interviewRepository.findAll()).thenReturn(Flux.fromIterable(List.of(interview1, interview2, interview3)));
+
+        String document = """
+        query {
+            allInterview {
+                id, jobApplicationId, interviewDate, interviewer, description, status
+            }
+        }
+        """;
+
+        graphQlTester.document(document)
+            .execute()
+            .path("allInterview")
+            .entityList(Interview.class)
+            .hasSize(3);
+
+        verify(interviewRepository, times(1)).findAll();
+    }
+
+    @Test
+    void testFindById() {
+        when(interviewRepository.findById(1)).thenReturn(Mono.just(interview1));
+
+        String document = """
+        query {
+            interviewById(id: 1) {
+                id, jobApplicationId, interviewDate, interviewer, description, status
+            }
+        }
+        """;
+
+        graphQlTester.document(document)
+            .execute()
+            .path("interviewById")
+            .entity(Interview.class)
+            .isEqualTo(interview1);
+
+        verify(interviewRepository, times(1)).findById(1);
+    }
+
+	@Test
+	void testAllInterviewByJobApplicationId() {
+		when(interviewRepository.findAllByJobApplicationId(1)).thenReturn(Flux.fromIterable(List.of(interview1, interview2)));
+
+        String document = """
+        query {
+            allInterviewByJobApplicationId(jobApplicationId: 1) {
+                id, jobApplicationId, interviewDate, interviewer, description, status
+            }
+        }
+        """;
+
+		graphQlTester.document(document)
+			.execute()
+			.path("allInterviewByJobApplicationId")
+			.entityList(Interview.class)
+			.hasSize(2)
+			.contains(interview1, interview2);
+
+		verify(interviewRepository, times(1)).findAllByJobApplicationId(1);
+	}
+
+    @Test
+    void testAllInterviewByJobApplicationIdWhenOnlyOneMatches() {
+        when(interviewRepository.findAllByJobApplicationId(2)).thenReturn(Flux.just(interview3));
+
+        String document = """
+        query {
+            allInterviewByJobApplicationId(jobApplicationId: 2) {
+                id, jobApplicationId, interviewDate, interviewer, description, status
+            }
+        }
+        """;
+
+        graphQlTester.document(document)
+            .execute()
+            .path("allInterviewByJobApplicationId")
+            .entityList(Interview.class)
+            .hasSize(1)
+            .contains(interview3);
+
+        verify(interviewRepository, times(1)).findAllByJobApplicationId(2);
+    }
+
+    @Test
+    void testAllInterviewByJobApplicationIdWhenNoMatch() {
+        when(interviewRepository.findAllByJobApplicationId(999)).thenReturn(Flux.empty());
+
+        String document = """
+        query {
+            allInterviewByJobApplicationId(jobApplicationId: 999) {
+                id, jobApplicationId, interviewDate, interviewer, description, status
+            }
+        }
+        """;
+
+        graphQlTester.document(document)
+            .execute()
+            .path("allInterviewByJobApplicationId")
+            .entityList(Interview.class)
+            .hasSize(0);
+
+        verify(interviewRepository, times(1)).findAllByJobApplicationId(999);
+    }
+
+	@Test
+	void testAddInterview() {
+
+		when(interviewRepository.save(any(Interview.class))).thenReturn(Mono.just(interview1));
+
+        String document = """
+        mutation AddInterview {
+            addInterview(interviewInput: {
+                jobApplicationId: 1,
+                interviewDate: "2024-09-02",
+                interviewer: "John Doe",
+                description: "Technical interview",
+                status: "scheduled"
+            }) {
+                id
+                jobApplicationId
+                interviewDate
+                interviewer
+                description
+                status
+            }
+        }
+        """;
+
+        graphQlTester.document(document)
+            .execute()
+            .path("addInterview.description")
+			.entity(String.class)
+			.isEqualTo("Technical interview");
+
+		verify(interviewRepository, times(1)).save(any(Interview.class));
+	}
+
+	@Test
+	void testUpdateInterview() {
+
+		when(interviewRepository.findById(1)).thenReturn(Mono.just(interview1));
+        when(interviewRepository.save(any(Interview.class))).thenReturn(Mono.just(interview1_updated));
+
+        String document = """
+        mutation UpdateInterview {
+            updateInterview(id: 1, interview: {
+                id: 1,
+                jobApplicationId: 1,
+                interviewDate: "2024-09-02",
+                interviewer: "John Doe",
+                description: "Technical interview",
+                status: "closed"
+            }) {
+                id
+                jobApplicationId
+                interviewDate
+                interviewer
+                description
+                status
+            }
+        }
+        """;
+
+        graphQlTester.document(document)
+            .execute()
+            .path("updateInterview.status")
+            .entity(String.class)
+            .isEqualTo("closed");
+
+		verify(interviewRepository, times(1)).findById(1);
+		verify(interviewRepository, times(1)).save(any(Interview.class));
+	}
+}

--- a/src/test/java/com/tnite/jobwinner/controller/JobApplicationGraphQlTest.java
+++ b/src/test/java/com/tnite/jobwinner/controller/JobApplicationGraphQlTest.java
@@ -1,111 +1,223 @@
 package com.tnite.jobwinner.controller;
 
 
-import java.time.LocalDate;
-import java.util.List;
-
+import com.tnite.jobwinner.model.Interview;
+import com.tnite.jobwinner.model.JobApplication;
+import com.tnite.jobwinner.repo.JobApplicationRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.graphql.tester.AutoConfigureGraphQlTester;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.graphql.test.tester.GraphQlTester;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
-import com.tnite.jobwinner.model.JobApplication;
-import com.tnite.jobwinner.repo.JobApplicationRepository;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 
 @SpringBootTest
 @AutoConfigureGraphQlTester
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@TestPropertySource(properties = {
+    "spring.r2dbc.url=r2dbc:h2:mem:///testdb-${random.uuid}",
+    "spring.r2dbc.generate-unique-name=true",
+})
+@ExtendWith(MockitoExtension.class)
 public class JobApplicationGraphQlTest {
 
     @Autowired
     private GraphQlTester graphQlTester;
     
-    @Autowired
+    @MockBean
     JobApplicationRepository jobApplicationRepository;
-    
+
+    private JobApplication jobApplication1;
+    private JobApplication jobApplication2;
+    private JobApplication jobApplication3;
+    private JobApplication jobApplication4;
+    private JobApplication jobApplication1_updated;
+    private List<JobApplication> jobApplicationList;
+
     @BeforeEach
     void setUp() {
-      List<JobApplication> jobApplications = List.of(new JobApplication(null, "A", "SWE", "100-200", "http://a.com", LocalDate.now(), "whatever1", "whatever1"),
-      new JobApplication(null, "B", "DE", "110-210", "http://b.com", LocalDate.now(), "whatever2", "whatever2"),
-      new JobApplication(null, "C", "QA", "120-220", "http://c.com", LocalDate.now(), "whatever3", "whatever3"));
-            jobApplicationRepository.deleteAll()
-              .thenMany(jobApplicationRepository.saveAll(jobApplications)).log().blockLast();
+        jobApplication1 = new JobApplication();
+        jobApplication1.setId(1);
+        jobApplication1.setCompanyName("Company A");
+        jobApplication1.setJobTitle("Developer");
+        jobApplication1.setAppliedDate(LocalDate.of(2023, 9, 10));
+        jobApplication1.setDescription("Description A");
+        jobApplication1.setSalaryRange("1000-2000");
+        jobApplication1.setJobUrl("http://companyA.com");
+        jobApplication1.setStatus("Applied");
+
+        jobApplication2 = new JobApplication();
+        jobApplication2.setId(2);
+        jobApplication2.setCompanyName("Company B");
+        jobApplication2.setJobTitle("Manager");
+        jobApplication2.setAppliedDate(LocalDate.of(2023, 9, 11));
+        jobApplication2.setDescription("Description B");
+        jobApplication2.setSalaryRange("2000-3000");
+        jobApplication2.setJobUrl("http://companyB.com");
+        jobApplication2.setStatus("Interview");
+
+        jobApplication3 = new JobApplication();
+        jobApplication3.setId(3);
+        jobApplication3.setCompanyName("Company C");
+        jobApplication3.setJobTitle("Tester");
+        jobApplication3.setAppliedDate(LocalDate.of(2023, 9, 12));
+        jobApplication3.setDescription("Description C");
+        jobApplication3.setSalaryRange("1500-2500");
+        jobApplication3.setJobUrl("http://companyC.com");
+        jobApplication3.setStatus("Offer");
+
+        jobApplicationList = Arrays.asList(jobApplication1, jobApplication2, jobApplication3);
+
+        jobApplication4 = new JobApplication();
+        jobApplication4.setId(4);
+        jobApplication4.setCompanyName("some copmany");
+        jobApplication4.setJobTitle("some title");
+        jobApplication4.setAppliedDate(LocalDate.of(2023, 1, 1));
+        jobApplication4.setDescription("whatever");
+        jobApplication4.setSalaryRange("100-200");
+        jobApplication4.setJobUrl("some url");
+        jobApplication4.setStatus("whatever");
+
+        jobApplication1_updated = new JobApplication();
+        jobApplication1_updated.setId(1);
+        jobApplication1_updated.setCompanyName("some copmany");
+        jobApplication1_updated.setJobTitle("some title");
+        jobApplication1_updated.setAppliedDate(LocalDate.of(2023, 1, 1));
+        jobApplication1_updated.setDescription("whatever");
+        jobApplication1_updated.setSalaryRange("100-200");
+        jobApplication1_updated.setJobUrl("some url");
+        jobApplication1_updated.setStatus("whatever");
     }
-        
-    
-        
+
     @Test
-    void allJobApplicationTest() {
-        
+    void testAllJobApplication() {
+
+        when(jobApplicationRepository.findAll()).thenReturn(Flux.fromIterable(jobApplicationList));
+
         String document = """
         query {
-              allJobApplication {
-                    id, description, jobTitle, jobUrl, status, appliedDate
-              }
+            allJobApplication {
+                id, description, jobTitle, jobUrl, status, appliedDate
             }
+        }
         """;
-        
+
         graphQlTester.document(document)
             .execute()
             .path("allJobApplication")
             .entityList(JobApplication.class)
             .hasSize(3);
-        
     }
-    
+
     @Test
-    void addJobApplicationTest() {
-        
+    void testAddJobApplication() {
+
+        when(jobApplicationRepository.save(any(JobApplication.class))).thenReturn(Mono.just(jobApplication4));
+
         String document = """
         mutation{
-          addJobApplication(addJobApplicationInput: {
-            companyName:"some copmany",
-            jobTitle:"some title"
-            salaryRange:"100-200",
-            appliedDate:"2023-01-01",
-            status:"whatever",
-            jobUrl: "some url",
-            description: "whatever"
-          }) {
-            id, jobTitle, description
-          }
+            addJobApplication(addJobApplicationInput: {
+                companyName:"some copmany",
+                jobTitle:"some title"
+                salaryRange:"100-200",
+                appliedDate:"2023-01-01",
+                status:"whatever",
+                jobUrl: "some url",
+                description: "whatever"
+            }) {
+                id, jobTitle, description
+            }
         }
         """;
-        
+
         graphQlTester.document(document)
             .execute()
             .path("addJobApplication.description")
             .entity(String.class)
             .isEqualTo("whatever");
-        
+
     }
-        
+
     @Test
-    void deleteApplicationTest() {
-        
+    void testUpdateJobApplication() {
+
+        when(jobApplicationRepository.findById(1)).thenReturn(Mono.just(jobApplication1));
+        when(jobApplicationRepository.save(any(JobApplication.class))).thenReturn(Mono.just(jobApplication1_updated));
+
         String document = """
-        mutation{
-          deleteJobApplication(id:1) {
-            id, description, status, jobTitle
-          }
+        mutation UpdateJobApplication {
+            updateJobApplication(jobApplication: {
+                id: 1
+                companyName:"some copmany",
+                jobTitle:"some title"
+                salaryRange:"100-200",
+                appliedDate:"2023-01-01",
+                status:"whatever",
+                jobUrl: "some url",
+                description: "whatever"
+            }) {
+                id
+                companyName
+                jobTitle
+                salaryRange
+                appliedDate
+                status
+                jobUrl
+                description
+            }
         }
         """;
-        
+
+        graphQlTester.document(document)
+            .execute()
+            .path("updateJobApplication.status")
+            .entity(String.class)
+            .isEqualTo("whatever");
+
+        verify(jobApplicationRepository, times(1)).findById(1);
+        verify(jobApplicationRepository, times(1)).save(any(JobApplication.class));
+    }
+
+    @Test
+    void testDeleteApplication() {
+        when(jobApplicationRepository.findById(1)).thenReturn(Mono.just(jobApplication1));
+        when(jobApplicationRepository.delete(jobApplication1)).thenReturn(Mono.empty());
+
+        String document = """
+        mutation{
+            deleteJobApplication(id:1) {
+                id, description, status, jobTitle
+            }
+        }
+        """;
+
         graphQlTester.document(document)
             .execute()
             .path("deleteJobApplication.jobTitle")
-            .entity(String.class)
-            .isEqualTo("SWE");
-        
+            .entity(String.class) // This assertion is to check that the mutation is executed
+            .isEqualTo("Developer");
+
     }
 
     @Test
     void testSearchJobApplications() {
+        when(jobApplicationRepository.searchJobApplications(anyString())).thenReturn(Flux.fromIterable(jobApplicationList));
         graphQlTester.document(getSearchQueryFromSearchTerm("whatever"))
             .execute()
             .path("searchJobApplications")
@@ -115,7 +227,8 @@ public class JobApplicationGraphQlTest {
 
     @Test
     void testSearchJobApplicationsWhenOnlyOneMatches() {
-        graphQlTester.document(getSearchQueryFromSearchTerm("qA"))
+        when(jobApplicationRepository.searchJobApplications(anyString())).thenReturn(Flux.just(jobApplication1));
+        graphQlTester.document(getSearchQueryFromSearchTerm("one"))
             .execute()
             .path("searchJobApplications")
             .entityList(JobApplication.class)
@@ -124,6 +237,7 @@ public class JobApplicationGraphQlTest {
 
     @Test
     void testSearchJobApplicationsWhenNoMatch() {
+        when(jobApplicationRepository.searchJobApplications(anyString())).thenReturn(Flux.empty());
         graphQlTester.document(getSearchQueryFromSearchTerm("bogus"))
             .execute()
             .path("searchJobApplications")
@@ -142,7 +256,5 @@ public class JobApplicationGraphQlTest {
         }
         """, searchTerm);
     }
-
-
 
 }

--- a/src/test/java/com/tnite/jobwinner/service/InterviewServiceTest.java
+++ b/src/test/java/com/tnite/jobwinner/service/InterviewServiceTest.java
@@ -1,0 +1,111 @@
+package com.tnite.jobwinner.service;
+
+import com.tnite.jobwinner.model.Interview;
+import com.tnite.jobwinner.model.AddInterviewInput;
+import com.tnite.jobwinner.repo.InterviewRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.LocalDate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class InterviewServiceTest {
+
+	@Mock
+	private InterviewRepository interviewRepository;
+
+	@InjectMocks
+	private InterviewService interviewService;
+
+	private Interview mockInterview1;
+	private Interview mockInterview2;
+	private AddInterviewInput mockInterviewInput;
+	private Interview mockUpdatedInterview;
+
+	@BeforeEach
+	void setUp() {
+		mockInterview1 = new Interview(1, 1, LocalDate.now(), "John Doe", "Technical Interview", "scheduled");
+		mockInterview2 = new Interview(2, 1, LocalDate.now(), "Jane Doe", "HR Interview", "closed");
+		mockInterviewInput = new AddInterviewInput(1, LocalDate.now(), "John Doe", "Technical Interview", "scheduled");
+		mockUpdatedInterview = new Interview(1, 1, LocalDate.now(), "John Doe", "Technical Interview", "closed");
+	}
+
+	@Test
+	void testAddInterview() {
+		when(interviewRepository.save(any(Interview.class))).thenReturn(Mono.just(mockInterview1));
+
+		Mono<Interview> result = interviewService.addInterview(mockInterviewInput);
+
+		StepVerifier.create(result)
+			.expectNextMatches(savedInterview -> savedInterview.getJobApplicationId().equals(mockInterviewInput.getJobApplicationId()))
+			.verifyComplete();
+
+		verify(interviewRepository, times(1)).save(any(Interview.class));
+	}
+
+	@Test
+	void testUpdateInterview() {
+		when(interviewRepository.findById(1)).thenReturn(Mono.just(mockInterview1));
+		when(interviewRepository.save(any(Interview.class))).thenReturn(Mono.just(mockUpdatedInterview));
+
+		Mono<Interview> result = interviewService.updateInterview(mockUpdatedInterview);
+
+		StepVerifier.create(result)
+			.expectNextMatches(interview -> interview.getStatus().equals("closed"))
+			.verifyComplete();
+
+		verify(interviewRepository, times(1)).findById(1);
+		verify(interviewRepository, times(1)).save(any(Interview.class));
+	}
+
+	@Test
+	void getInterviewByJobApplicationId() {
+		when(interviewRepository.findAllByJobApplicationId(1)).thenReturn(Flux.just(mockInterview1, mockInterview2));
+
+		Flux<Interview> result = interviewService.getInterviewByJobApplicationId(1);
+
+		StepVerifier.create(result)
+			.expectNext(mockInterview1)
+			.expectNext(mockInterview2)
+			.verifyComplete();
+
+		verify(interviewRepository, times(1)).findAllByJobApplicationId(1);
+	}
+
+	@Test
+	void testGetInterview() {
+		when(interviewRepository.findById(1)).thenReturn(Mono.just(mockInterview1));
+
+		Mono<Interview> result = interviewService.getInterview(1);
+
+		StepVerifier.create(result)
+			.expectNextMatches(i -> i.getId().equals(1))
+			.verifyComplete();
+
+		verify(interviewRepository, times(1)).findById(1);
+	}
+
+	@Test
+	void testAllInterview() {
+		when(interviewRepository.findAll()).thenReturn(Flux.just(mockInterview1, mockInterview2));
+
+		Flux<Interview> result = interviewService.allInterview();
+
+		StepVerifier.create(result)
+			.expectNext(mockInterview1)
+			.expectNext(mockInterview2)
+			.verifyComplete();
+
+		verify(interviewRepository, times(1)).findAll();
+	}
+}

--- a/src/test/java/com/tnite/jobwinner/service/JobApplicationServiceTest.java
+++ b/src/test/java/com/tnite/jobwinner/service/JobApplicationServiceTest.java
@@ -6,7 +6,6 @@ import com.tnite.jobwinner.repo.JobApplicationRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -60,7 +59,7 @@ public class JobApplicationServiceTest {
 
 	@Test
 	void testAddJobApplication() {
-		when(jobApplicationRepository.save(ArgumentMatchers.any(JobApplication.class))).thenReturn(Mono.just(jobApplication1));
+		when(jobApplicationRepository.save(any(JobApplication.class))).thenReturn(Mono.just(jobApplication1));
 
 		Mono<JobApplication> result = jobApplicationService.addJobApplication(addJobApplicationInput1);
 


### PR DESCRIPTION
For both interview and offer:
- add create table  statements to schema.sql
- add mutation, type, query, input definition to schema.graphqls
- add model class definitions

More for interview:
- add controller, repository and service class
- add unit tests

Other change:
- refactor JobApplicationGraphQlTest to use mock instead of actual db (somehow it still rely on a in memory db which cause test data initialization and test data insertion problem. The fix is to generate a separate db per test script with random.uuid
- add more test to JobApplicationGGraphQlTest
- fix logging typo