### PR TITLE
Build and run app in docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,34 +90,45 @@ This is the backend for Job Winner and here is the stack:
 1. GraphQL
 1. Postgres DB
 
-## To build 
-
-Prereq: Java17
+## Create the Database
 
 1. Bring up the Postgres DB with docker-compose
 ```console
-docker-compose up -d
+docker-compose --profile db up -d
 ```
 1. Create the db schema with `src/main/resources/schema.sql`
     1. Visit http://localhost:8081/. Information can be found or modified [here](./src/main/resources/application.properties).
         1. User: `postgres`.
         1. Password: `example`.
         1. Click on `Import` and follow instructions to import file.
-1. Build the java app with Maven
+
+## (Optional) Build the App
+1. Build the java app with Maven. This runs by default when you bring up the app, so you don't _have_ to do it here.
 ```console
-mvn clean install
-java -jar target/job-winner-0.0.1-SNAPSHOT.jar
+docker-compose --profile build up
 ```
 
+## Run the App
+You should create the database ([above](#create-the-database)) first.
+
+This will build and run the app:
+```console
+docker-compose up -d
+```
+
+If you don't want to rebuild the app, you can run it this way:
+```console
+docker-compose --profile app up -d
+```
+
+Please follow the build instruction from the [UI repo](https://github.com/januschung/job-winner-ui) to bring up the UI.
+
+
+# Initializing and Running the Application with H2 Database
 Alternatively, you can run the java app with h2 database:
 ```console
-# Initializing and Running the Application with H2 Database (first time only)
-java -jar target/job-winner-0.0.1-SNAPSHOT.jar --spring.profiles.active=h2 --spring.sql.init.mode=always
-
-# Starting the Application When Database Already Exists
-java -jar target/job-winner-0.0.1-SNAPSHOT.jar --spring.profiles.active=h2
+SPRING_PROFILES_ACTIVE=h2 docker-compose --profile app up -d
 ```
-Please follow the build instruction from the [UI repo](https://github.com/januschung/job-winner-ui) to bring up the UI.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -90,45 +90,57 @@ This is the backend for Job Winner and here is the stack:
 1. GraphQL
 1. Postgres DB
 
-## Create the Database
-
-1. Bring up the Postgres DB with docker-compose
+## Build the App
+1. Build the java app with Maven.
 ```console
-docker-compose --profile db up -d
-```
-1. Create the db schema with `src/main/resources/schema.sql`
-    1. Visit http://localhost:8081/. Information can be found or modified [here](./src/main/resources/application.properties).
-        1. User: `postgres`.
-        1. Password: `example`.
-        1. Click on `Import` and follow instructions to import file.
-
-## (Optional) Build the App
-1. Build the java app with Maven. This runs by default when you bring up the app, so you don't _have_ to do it here.
-```console
-docker-compose --profile build up
+docker-compose up builder
 ```
 
-## Run the App
-You should create the database ([above](#create-the-database)) first.
+## Running the App
 
-This will build and run the app:
+You have two options for data persistence:
+* **PostgreSQL**, a SQL database instance suitable for production releases
+* **H2**, a much simpler in-memory store (persisted in a file) that is useful for local testing
+
+### PostgreSQL
+
+1. Build the App with docker-compose
+```console
+docker-compose up builder
+```
+2. Run the App with docker compose. This will initialize the database automatically.
 ```console
 docker-compose up -d
 ```
 
-If you don't want to rebuild the app, you can run it this way:
-```console
-docker-compose --profile app up -d
-```
+3. Administer the database:
+    * Visit http://localhost:8081/. Information can be found or modified [here](./src/main/resources/application.properties).
+        * System: `PostgreSQL`
+        * Server: `db`
+        * User: `postgres`.
+        * Password: `example`.
+        * Database: `postgres`.
 
 Please follow the build instruction from the [UI repo](https://github.com/januschung/job-winner-ui) to bring up the UI.
 
+### H2
 
-# Initializing and Running the Application with H2 Database
-Alternatively, you can run the java app with h2 database:
+1. Build the App with docker-compose
 ```console
-SPRING_PROFILES_ACTIVE=h2 docker-compose --profile app up -d
+docker-compose up builder
 ```
+
+2. Initialize the H2 database and run the app (**Do this the first time you run it**)
+```console
+SPRING_SQL_INIT_MODE=always docker-compose up app-h2
+```
+
+3. Subsequent runs can skip the initialization:
+```
+docker-compose up app-h2
+```
+
+Please follow the build instruction from the [UI repo](https://github.com/januschung/job-winner-ui) to bring up the UI.
 
 ## Contributing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 services:
-  build:
+
+  # Build the .jar file using Maven
+  builder:
     profiles:
-      - "" # Run when no profile is selected
       - build
-      - app
     image: maven
     working_dir: /app
     entrypoint: ["mvn", "clean", "install"]
@@ -11,46 +11,51 @@ services:
       - .:/app
       - ./.mvn/.m2/cache:/root/.m2
 
-  app:
-    profiles:
-      - "" # Run when no profile is selected
-      - app
+  # Run the application in PostgreSQL mode
+  app: &app-base
     image: openjdk:17-jdk-alpine
+    environment:
+      SPRING_R2DBC_URL: r2dbc:postgresql://db:5432/postgres
     working_dir: /app
     entrypoint: ["java","-jar","/app/target/job-winner-0.0.1-SNAPSHOT.jar"]
-    environment:
-      - SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE} ## TODO: This doesn't seem to be working
     ports:
-      - 8000:8000
+      - 8080:8080
     volumes:
-      - .:/app:ro
+      - .:/app
     depends_on:
-      build:
-        condition: service_completed_successfully
-
-  db:
-    profiles:
-      - "" # Run when no profile is selected
       - db
-    build:
-      dockerfile: postgresDB.dockerfile
+  
+  # Run the application in H2 (local) mode
+  app-h2:
+    <<: *app-base
+    profiles:
+      - h2
+    environment:
+      SPRING_PROFILES_ACTIVE: h2
+      SPRING_SQL_INIT_MODE: ${SPRING_SQL_INIT_MODE:-}
+    depends_on: []
+
+  # PostgreSQL database
+  db:
+    image: postgres
     restart: always
     environment:
-      POSTGRES_PASSWORD: example
       POSTGRES_USERNAME: postgres
+      POSTGRES_PASSWORD: example
     ports:
       - 5432:5432
     volumes:
+      - "./src/main/resources/schema.sql:/docker-entrypoint-initdb.d/schema.sql:ro"
       - pgdata:/var/lib/postgresql/data
 
+  # Database Admin Panel
   adminer:
-    profiles:
-      - "" # Run when no profile is selected
-      - db
     image: adminer
     restart: always
     ports:
       - 8081:8080
+    depends_on:
+      - db
 
 volumes:
   pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,37 @@
 services:
+  build:
+    profiles:
+      - "" # Run when no profile is selected
+      - build
+      - app
+    image: maven
+    working_dir: /app
+    entrypoint: ["mvn", "clean", "install"]
+    volumes:
+      - .:/app
+      - ./.mvn/.m2/cache:/root/.m2
+
+  app:
+    profiles:
+      - "" # Run when no profile is selected
+      - app
+    image: openjdk:17-jdk-alpine
+    working_dir: /app
+    entrypoint: ["java","-jar","/app/target/job-winner-0.0.1-SNAPSHOT.jar"]
+    environment:
+      - SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE} ## TODO: This doesn't seem to be working
+    ports:
+      - 8000:8000
+    volumes:
+      - .:/app:ro
+    depends_on:
+      build:
+        condition: service_completed_successfully
+
   db:
+    profiles:
+      - "" # Run when no profile is selected
+      - db
     build:
       dockerfile: postgresDB.dockerfile
     restart: always
@@ -12,6 +44,9 @@ services:
       - pgdata:/var/lib/postgresql/data
 
   adminer:
+    profiles:
+      - "" # Run when no profile is selected
+      - db
     image: adminer
     restart: always
     ports:

--- a/postgresDB.dockerfile
+++ b/postgresDB.dockerfile
@@ -1,4 +1,0 @@
-FROM postgres
-ENV POSTGRES_PASSWORD=example
-ENV POSTGRES_USERNAME=postgres
-COPY src/main/resources/schema.sql /docker-entrypoint-initdb.d/


### PR DESCRIPTION
Build and run the application using docker compose

* Created a `builder` container that will build the application
* Created `app` and `app-h2` containers to run the application depending on preferred database
* Updated the `db` container and removed the `postgres.Dockerfile`, because we can use volumes to put the schema into the init directory.
* Updated README

You will probably notice that you _could_ set this up to run the application using h2 with only environment variables and not even a separate container or java profile. I felt like this was a little more complicated than I would prefer, but a future ticket might address this if desired.

Closes #53 